### PR TITLE
add ICS2025 on news and source

### DIFF
--- a/_data/news.yaml
+++ b/_data/news.yaml
@@ -1,3 +1,7 @@
+- content: 'Our paper <u>G^3SA: A GPU-Accelerated Gold Standard Genetics Library for End-to-End Sequence Alignment</u> has been accepted to ICS 2025. Congratulations to authors!'
+  print_date: Apr. 2025
+  date: 2025-04-10
+
 - content: 'Welcome to our lab, Dain Kwon and Jun Sung!'
   print_date: Jan. 2025
   date: 2025-01-01

--- a/_data/sources.yaml
+++ b/_data/sources.yaml
@@ -1,3 +1,17 @@
+- title: "G³SA: A GPU-Accelerated Gold Standard Genetics Library for End-to-End Sequence Alignment"
+  authors:
+    - Yeejoo Han
+    - Sunwoo Kim
+    - Seongyeon Park
+    - Jinho Lee
+  date: '2025-06-08'
+  publisher: International Conference on Supercomputing (ICS)
+  tags:
+    - Top Conf.
+    - AI/ML
+  image: images_paper/mimiq.png
+  id: ""
+
 - title: "MimiQ: Low-Bit Data-Free Quantization of Vision Transformers with Encouraging Inter-Head Attention Similarity"
   authors:
     - Kanghyun Choi


### PR DESCRIPTION
This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
